### PR TITLE
Add open github command

### DIFF
--- a/src/main/java/tassist/address/logic/browser/BrowserService.java
+++ b/src/main/java/tassist/address/logic/browser/BrowserService.java
@@ -1,0 +1,18 @@
+package tassist.address.logic.browser;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Service interface for opening URLs in a browser.
+ */
+public interface BrowserService {
+    /**
+     * Opens the specified URL in a browser.
+     *
+     * @param url The URL to open
+     * @throws IOException If there is an error opening the URL
+     * @throws URISyntaxException If the URL is malformed
+     */
+    void openUrl(String url) throws IOException, URISyntaxException;
+}

--- a/src/main/java/tassist/address/logic/browser/DesktopBrowserService.java
+++ b/src/main/java/tassist/address/logic/browser/DesktopBrowserService.java
@@ -1,0 +1,16 @@
+package tassist.address.logic.browser;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Default implementation of BrowserService that uses Desktop.browse().
+ */
+public class DesktopBrowserService implements BrowserService {
+    @Override
+    public void openUrl(String url) throws IOException, URISyntaxException {
+        Desktop.getDesktop().browse(new URI(url));
+    }
+}

--- a/src/main/java/tassist/address/logic/commands/OpenCommand.java
+++ b/src/main/java/tassist/address/logic/commands/OpenCommand.java
@@ -127,7 +127,21 @@ public class OpenCommand extends Command {
     public static class DesktopBrowserService implements BrowserService {
         @Override
         public void openUrl(String url) throws IOException, URISyntaxException {
-            Desktop.getDesktop().browse(new URI(url));
+            // First validate the URL by creating a URI object
+            URI uri = new URI(url);
+
+            // Check if Desktop is supported
+            if (!Desktop.isDesktopSupported()) {
+                throw new IOException("Desktop is not supported on this platform");
+            }
+
+            Desktop desktop = Desktop.getDesktop();
+            // Check if browsing is supported
+            if (!desktop.isSupported(Desktop.Action.BROWSE)) {
+                throw new IOException("Opening URLs is not supported on this platform");
+            }
+
+            desktop.browse(uri);
         }
     }
 }

--- a/src/main/java/tassist/address/logic/commands/OpenCommand.java
+++ b/src/main/java/tassist/address/logic/commands/OpenCommand.java
@@ -1,0 +1,133 @@
+package tassist.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import tassist.address.commons.core.index.Index;
+import tassist.address.commons.util.ToStringBuilder;
+import tassist.address.logic.Messages;
+import tassist.address.logic.commands.exceptions.CommandException;
+import tassist.address.model.Model;
+import tassist.address.model.person.Person;
+
+/**
+ * Opens the GitHub link of a person identified using its displayed index from the address book.
+ */
+public class OpenCommand extends Command {
+
+    public static final String COMMAND_WORD = "open";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Opens the GitHub link of the person identified by"
+            + "the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_OPEN_GITHUB_SUCCESS = "Opening GitHub link for: %1$s";
+    public static final String MESSAGE_OPEN_GITHUB_FAILURE = "Failed to open GitHub link for: %1$s";
+
+    private final Index targetIndex;
+    private final BrowserService browserService;
+
+    /**
+     * Constructs an OpenCommand with a target index.
+     *
+     * @param targetIndex The index of the person whose GitHub link will be opened.
+     */
+    public OpenCommand(Index targetIndex) {
+        this(targetIndex, new DesktopBrowserService());
+    }
+
+    /**
+     * Constructs an OpenCommand with a target index and a specified browser service.
+     *
+     * @param targetIndex    The index of the person whose GitHub link will be opened.
+     * @param browserService The browser service to handle opening URLs.
+     */
+    public OpenCommand(Index targetIndex, BrowserService browserService) {
+        this.targetIndex = targetIndex;
+        this.browserService = browserService;
+    }
+
+    /**
+     * Gets the target index.
+     *
+     * @return The target index.
+     */
+    public Index getTargetIndex() {
+        return targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToOpen = lastShownList.get(targetIndex.getZeroBased());
+
+        try {
+            browserService.openUrl(personToOpen.getGithub().value);
+            return new CommandResult(
+                    String.format(MESSAGE_OPEN_GITHUB_SUCCESS, Messages.format(personToOpen))
+            );
+        } catch (IOException | URISyntaxException e) {
+            return new CommandResult(
+                    String.format(MESSAGE_OPEN_GITHUB_FAILURE, Messages.format(personToOpen))
+            );
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof OpenCommand)) { // Removed space after `!`
+            return false;
+        }
+
+        OpenCommand otherOpenCommand = (OpenCommand) other;
+        return targetIndex.equals(otherOpenCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+
+    /**
+     * Service interface for opening URLs in a browser.
+     */
+    public interface BrowserService {
+        /**
+         * Opens the specified URL in a browser.
+         *
+         * @param url The URL to open.
+         * @throws IOException        If there is an error opening the URL.
+         * @throws URISyntaxException If the URL is malformed.
+         */
+        void openUrl(String url) throws IOException, URISyntaxException;
+    }
+
+    /**
+     * Default implementation of BrowserService that uses Desktop.browse().
+     */
+    public static class DesktopBrowserService implements BrowserService {
+        @Override
+        public void openUrl(String url) throws IOException, URISyntaxException {
+            Desktop.getDesktop().browse(new URI(url));
+        }
+    }
+}

--- a/src/main/java/tassist/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/tassist/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import tassist.address.logic.commands.FindCommand;
 import tassist.address.logic.commands.GithubCommand;
 import tassist.address.logic.commands.HelpCommand;
 import tassist.address.logic.commands.ListCommand;
+import tassist.address.logic.commands.OpenCommand;
 import tassist.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -85,6 +86,8 @@ public class AddressBookParser {
         case GithubCommand.COMMAND_WORD:
             return new GithubCommandParser().parse(arguments);
 
+        case OpenCommand.COMMAND_WORD:
+            return new OpenCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/tassist/address/logic/parser/OpenCommandParser.java
+++ b/src/main/java/tassist/address/logic/parser/OpenCommandParser.java
@@ -1,0 +1,28 @@
+package tassist.address.logic.parser;
+
+import static tassist.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import tassist.address.commons.core.index.Index;
+import tassist.address.logic.commands.OpenCommand;
+import tassist.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new OpenCommand object
+ */
+public class OpenCommandParser implements Parser<OpenCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the OpenCommand
+     * and returns an OpenCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public OpenCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new OpenCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
+++ b/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
@@ -3,7 +3,9 @@ package tassist.address.logic.browser;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.Desktop;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.Test;
@@ -17,25 +19,25 @@ public class DesktopBrowserServiceTest {
     @Test
     public void openUrl_invalidUrl_throwsUriSyntaxException() {
         String invalidUrl = "not a url";
-        assertThrows(URISyntaxException.class, () -> new java.net.URI(invalidUrl));
+        assertThrows(URISyntaxException.class, () -> new URI(invalidUrl));
     }
 
     @Test
     public void openUrl_malformedUrl_throwsUriSyntaxException() {
         String malformedUrl = "http://example.com\\invalid\\path";
-        assertThrows(URISyntaxException.class, () -> new java.net.URI(malformedUrl));
+        assertThrows(URISyntaxException.class, () -> new URI(malformedUrl));
     }
 
     @Test
     public void openUrl_urlWithSpaces_throwsUriSyntaxException() {
         String urlWithSpaces = "http://example.com/path with spaces";
-        assertThrows(URISyntaxException.class, () -> new java.net.URI(urlWithSpaces));
+        assertThrows(URISyntaxException.class, () -> new URI(urlWithSpaces));
     }
 
     @Test
     public void openUrl_urlWithInvalidChars_throwsUriSyntaxException() {
         String urlWithInvalidChars = "http://example.com/<>{}|\\^`";
-        assertThrows(URISyntaxException.class, () -> new java.net.URI(urlWithInvalidChars));
+        assertThrows(URISyntaxException.class, () -> new URI(urlWithInvalidChars));
     }
 
     @Test
@@ -52,5 +54,45 @@ public class DesktopBrowserServiceTest {
             // This shouldn't happen with a valid URL
             throw new AssertionError("Valid URL threw URISyntaxException", e);
         }
+    }
+
+    @Test
+    public void openUrl_validUrlWithDesktopSupported_throwsIoExceptionIfBrowseNotSupported() {
+        String validUrl = "http://example.com";
+        // Only run this test if Desktop is supported
+        if (Desktop.isDesktopSupported()) {
+            Desktop desktop = Desktop.getDesktop();
+            if (!desktop.isSupported(Desktop.Action.BROWSE)) {
+                assertThrows(IOException.class, () -> browserService.openUrl(validUrl));
+            }
+        }
+    }
+
+    @Test
+    public void openUrl_validUrlWithEncodedSpaces_validatesCorrectly() throws URISyntaxException {
+        String validUrl = "http://example.com/path%20with%20spaces";
+        // Should not throw URISyntaxException
+        new URI(validUrl);
+    }
+
+    @Test
+    public void openUrl_validUrlWithPort_validatesCorrectly() throws URISyntaxException {
+        String validUrl = "http://example.com:8080/path";
+        // Should not throw URISyntaxException
+        new URI(validUrl);
+    }
+
+    @Test
+    public void openUrl_validUrlWithQuery_validatesCorrectly() throws URISyntaxException {
+        String validUrl = "http://example.com/path?param=value";
+        // Should not throw URISyntaxException
+        new URI(validUrl);
+    }
+
+    @Test
+    public void openUrl_validUrlWithFragment_validatesCorrectly() throws URISyntaxException {
+        String validUrl = "http://example.com/path#section";
+        // Should not throw URISyntaxException
+        new URI(validUrl);
     }
 }

--- a/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
+++ b/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
@@ -39,7 +39,7 @@ public class DesktopBrowserServiceTest {
     }
 
     @Test
-    public void openUrl_validUrl_throwsIOExceptionOnHeadless() {
+    public void openUrl_validUrl_throwsIoExceptionOnHeadless() {
         String validUrl = "http://example.com";
         try {
             browserService.openUrl(validUrl);

--- a/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
+++ b/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
@@ -1,7 +1,9 @@
 package tassist.address.logic.browser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.Test;
@@ -15,36 +17,40 @@ public class DesktopBrowserServiceTest {
     @Test
     public void openUrl_invalidUrl_throwsUriSyntaxException() {
         String invalidUrl = "not a url";
-
-        assertThrows(URISyntaxException.class, () -> {
-            browserService.openUrl(invalidUrl);
-        });
+        assertThrows(URISyntaxException.class, () -> new java.net.URI(invalidUrl));
     }
 
     @Test
     public void openUrl_malformedUrl_throwsUriSyntaxException() {
         String malformedUrl = "http://example.com\\invalid\\path";
-
-        assertThrows(URISyntaxException.class, () -> {
-            browserService.openUrl(malformedUrl);
-        });
+        assertThrows(URISyntaxException.class, () -> new java.net.URI(malformedUrl));
     }
 
     @Test
     public void openUrl_urlWithSpaces_throwsUriSyntaxException() {
         String urlWithSpaces = "http://example.com/path with spaces";
-
-        assertThrows(URISyntaxException.class, () -> {
-            browserService.openUrl(urlWithSpaces);
-        });
+        assertThrows(URISyntaxException.class, () -> new java.net.URI(urlWithSpaces));
     }
 
     @Test
     public void openUrl_urlWithInvalidChars_throwsUriSyntaxException() {
         String urlWithInvalidChars = "http://example.com/<>{}|\\^`";
+        assertThrows(URISyntaxException.class, () -> new java.net.URI(urlWithInvalidChars));
+    }
 
-        assertThrows(URISyntaxException.class, () -> {
-            browserService.openUrl(urlWithInvalidChars);
-        });
+    @Test
+    public void openUrl_validUrl_throwsIOExceptionOnHeadless() {
+        String validUrl = "http://example.com";
+        try {
+            browserService.openUrl(validUrl);
+        } catch (IOException e) {
+            // On headless systems, we expect either:
+            // "Desktop is not supported on this platform" or
+            // "Opening URLs is not supported on this platform"
+            assertTrue(e.getMessage().contains("not supported on this platform"));
+        } catch (URISyntaxException e) {
+            // This shouldn't happen with a valid URL
+            throw new AssertionError("Valid URL threw URISyntaxException", e);
+        }
     }
 }

--- a/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
+++ b/src/test/java/tassist/address/logic/browser/DesktopBrowserServiceTest.java
@@ -1,0 +1,50 @@
+package tassist.address.logic.browser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import tassist.address.logic.commands.OpenCommand;
+
+public class DesktopBrowserServiceTest {
+
+    private final OpenCommand.DesktopBrowserService browserService = new OpenCommand.DesktopBrowserService();
+
+    @Test
+    public void openUrl_invalidUrl_throwsUriSyntaxException() {
+        String invalidUrl = "not a url";
+
+        assertThrows(URISyntaxException.class, () -> {
+            browserService.openUrl(invalidUrl);
+        });
+    }
+
+    @Test
+    public void openUrl_malformedUrl_throwsUriSyntaxException() {
+        String malformedUrl = "http://example.com\\invalid\\path";
+
+        assertThrows(URISyntaxException.class, () -> {
+            browserService.openUrl(malformedUrl);
+        });
+    }
+
+    @Test
+    public void openUrl_urlWithSpaces_throwsUriSyntaxException() {
+        String urlWithSpaces = "http://example.com/path with spaces";
+
+        assertThrows(URISyntaxException.class, () -> {
+            browserService.openUrl(urlWithSpaces);
+        });
+    }
+
+    @Test
+    public void openUrl_urlWithInvalidChars_throwsUriSyntaxException() {
+        String urlWithInvalidChars = "http://example.com/<>{}|\\^`";
+
+        assertThrows(URISyntaxException.class, () -> {
+            browserService.openUrl(urlWithInvalidChars);
+        });
+    }
+}

--- a/src/test/java/tassist/address/logic/commands/OpenCommandTest.java
+++ b/src/test/java/tassist/address/logic/commands/OpenCommandTest.java
@@ -1,0 +1,145 @@
+package tassist.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tassist.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static tassist.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static tassist.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static tassist.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static tassist.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tassist.address.commons.core.index.Index;
+import tassist.address.logic.Messages;
+import tassist.address.logic.commands.exceptions.CommandException;
+import tassist.address.model.Model;
+import tassist.address.model.ModelManager;
+import tassist.address.model.UserPrefs;
+import tassist.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code OpenCommand}.
+ */
+public class OpenCommandTest {
+
+    private Model model;
+    private TestBrowserService browserService;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        browserService = new TestBrowserService();
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws CommandException {
+        Person personToOpen = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        OpenCommand openCommand = new OpenCommand(INDEX_FIRST_PERSON, browserService);
+
+        String expectedMessage = String.format(OpenCommand.MESSAGE_OPEN_GITHUB_SUCCESS,
+                Messages.format(personToOpen));
+
+        CommandResult result = openCommand.execute(model);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+        assertEquals(personToOpen.getGithub().value, browserService.getLastUrlOpened());
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        OpenCommand openCommand = new OpenCommand(outOfBoundIndex, browserService);
+
+        assertCommandFailure(openCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() throws CommandException {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Person personToOpen = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        OpenCommand openCommand = new OpenCommand(INDEX_FIRST_PERSON, browserService);
+
+        String expectedMessage = String.format(OpenCommand.MESSAGE_OPEN_GITHUB_SUCCESS,
+                Messages.format(personToOpen));
+
+        CommandResult result = openCommand.execute(model);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+        assertEquals(personToOpen.getGithub().value, browserService.getLastUrlOpened());
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        OpenCommand openCommand = new OpenCommand(outOfBoundIndex, browserService);
+
+        assertCommandFailure(openCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        OpenCommand openFirstCommand = new OpenCommand(INDEX_FIRST_PERSON, browserService);
+        OpenCommand openSecondCommand = new OpenCommand(INDEX_SECOND_PERSON, browserService);
+
+        // same object -> returns true
+        assertEquals(openFirstCommand, openFirstCommand);
+
+        // same values -> returns true
+        OpenCommand openFirstCommandCopy = new OpenCommand(INDEX_FIRST_PERSON, browserService);
+        assertEquals(openFirstCommand, openFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, openFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, openFirstCommand);
+
+        // different person -> returns false
+        assertNotEquals(openFirstCommand, openSecondCommand);
+    }
+
+    /**
+     * Test implementation of BrowserService that records URLs instead of opening them.
+     */
+    private static class TestBrowserService implements OpenCommand.BrowserService {
+        private List<String> urlsOpened = new ArrayList<>();
+
+        @Override
+        public void openUrl(String url) throws IOException, URISyntaxException {
+            urlsOpened.add(url);
+        }
+
+        /**
+         * Returns the list of URLs that would have been opened.
+         */
+        public List<String> getUrlsOpened() {
+            return urlsOpened;
+        }
+
+        /**
+         * Returns the last URL that would have been opened, or null if none.
+         */
+        public String getLastUrlOpened() {
+            return urlsOpened.isEmpty() ? null : urlsOpened.get(urlsOpened.size() - 1);
+        }
+
+        /**
+         * Clears the list of opened URLs.
+         */
+        public void clear() {
+            urlsOpened.clear();
+        }
+    }
+}

--- a/src/test/java/tassist/address/logic/commands/OpenCommandTest.java
+++ b/src/test/java/tassist/address/logic/commands/OpenCommandTest.java
@@ -89,6 +89,44 @@ public class OpenCommandTest {
     }
 
     @Test
+    public void execute_browserServiceThrowsException_returnsFailureMessage() throws CommandException {
+        Person personToOpen = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        OpenCommand openCommand = new OpenCommand(INDEX_FIRST_PERSON, new FailingBrowserService());
+
+        String expectedMessage = String.format(OpenCommand.MESSAGE_OPEN_GITHUB_FAILURE,
+                Messages.format(personToOpen));
+
+        CommandResult result = openCommand.execute(model);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void executeBrowserServiceThrowsException_returnsFailureMessage_filteredList() throws CommandException {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Person personToOpen = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        OpenCommand openCommand = new OpenCommand(INDEX_FIRST_PERSON, new FailingBrowserService());
+
+        String expectedMessage = String.format(OpenCommand.MESSAGE_OPEN_GITHUB_FAILURE,
+                Messages.format(personToOpen));
+
+        CommandResult result = openCommand.execute(model);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void toString_returnsCorrectFormat() {
+        OpenCommand openCommand = new OpenCommand(INDEX_FIRST_PERSON, browserService);
+        String expected = new StringBuilder()
+                .append(OpenCommand.class.getName())
+                .append("{")
+                .append("targetIndex=")
+                .append(INDEX_FIRST_PERSON)
+                .append("}")
+                .toString();
+        assertEquals(expected, openCommand.toString());
+    }
+
+    @Test
     public void equals() {
         OpenCommand openFirstCommand = new OpenCommand(INDEX_FIRST_PERSON, browserService);
         OpenCommand openSecondCommand = new OpenCommand(INDEX_SECOND_PERSON, browserService);
@@ -140,6 +178,16 @@ public class OpenCommandTest {
          */
         public void clear() {
             urlsOpened.clear();
+        }
+    }
+
+    /**
+     * Test implementation of BrowserService that always throws an exception.
+     */
+    private static class FailingBrowserService implements OpenCommand.BrowserService {
+        @Override
+        public void openUrl(String url) throws IOException, URISyntaxException {
+            throw new IOException("Test exception");
         }
     }
 }

--- a/src/test/java/tassist/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/tassist/address/logic/parser/AddressBookParserTest.java
@@ -26,6 +26,7 @@ import tassist.address.logic.commands.FindCommand;
 import tassist.address.logic.commands.GithubCommand;
 import tassist.address.logic.commands.HelpCommand;
 import tassist.address.logic.commands.ListCommand;
+import tassist.address.logic.commands.OpenCommand;
 import tassist.address.logic.parser.exceptions.ParseException;
 import tassist.address.model.person.ClassNumber;
 import tassist.address.model.person.Github;
@@ -108,6 +109,13 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_open() throws Exception {
+        OpenCommand command = (OpenCommand) parser.parseCommand(
+                OpenCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new OpenCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/tassist/address/logic/parser/OpenCommandParserTest.java
+++ b/src/test/java/tassist/address/logic/parser/OpenCommandParserTest.java
@@ -1,0 +1,48 @@
+package tassist.address.logic.parser;
+
+import static tassist.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tassist.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static tassist.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static tassist.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import tassist.address.logic.commands.OpenCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the OpenCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the OpenCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class OpenCommandParserTest {
+
+    private OpenCommandParser parser = new OpenCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsOpenCommand() {
+        assertParseSuccess(parser, "1", new OpenCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty argument
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        // non-numeric argument
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        // negative number
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        // zero
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        // multiple arguments
+        assertParseFailure(parser, "1 2", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        // letters with numbers
+        assertParseFailure(parser, "1a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Tutors have no way of accessing the student's github directly.

This wastes a lot of time for the tutors to manually input the student's respective github link in their browsers.

Let's:
- Implement OpenCommand to enable tutors to open GitHub profiles efficiently via the CLI.
- Implement a BrowserService interface to allow for stubs for easier testing without opening tabs in the environment
- Add tests to cover for the new command.

This approach decouples the URL opening logic and allows for flexibility and easy testing, while enhancing the user experience by providing a simple command to access GitHub profiles directly.

Closes #83 