### PR TITLE
Assignment improvements

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -329,7 +329,8 @@ Format: `assignment n/NAME d/DATE`
 * `n/NAME`: The title or description of the assignment/event.
 * `d/DATE`: The deadline for the assignment/event.
 * Accepted date formats: `dd-MM-yyyy`, `dd-MM-yy`, or `dd-MM` (defaults to current year)
-* The date must be a valid **future date**.
+* The date must be a valid **future date** starting from tomorrow.
+
 
 Examples:
 * `assignment n/CS2103T Project d/30-01-2025` <br>
@@ -337,13 +338,15 @@ Examples:
 * `assignment n/Quiz 1 d/10-04` <br>
   Adds an event named "Quiz 1" with the deadline on April 10 of the current year.
 
-### Viewing the timed event list: `view`
+### Viewing the timed event list and their indices: `view`
 
 **Lists all timed events** in the system.
 
 Format: `view`
-* Shows all timed events with their names and deadlines
+* Shows all timed events with their names and deadlines, as well as their indices
 * **Tip:** enter `view` before [assigning](#assigning-a-timed-eventassignment-assign) an assignment to manage tasks easier.
+* Note that assignments that has past their deadlines are not deleted for track keeping purposes, refer to `unassign`\
+    to see how to remove them
 
 Example:<br>
   `view` followed by `assign 3 T01`

--- a/src/main/java/tassist/address/logic/parser/AssignmentCommandParser.java
+++ b/src/main/java/tassist/address/logic/parser/AssignmentCommandParser.java
@@ -21,9 +21,8 @@ import tassist.address.model.timedevents.Assignment;
 public class AssignmentCommandParser implements Parser<AssignmentCommand> {
 
     public static final String MESSAGE_INVALID_DATE = "Invalid date format. Use: dd-MM-yyyy, dd-MM-yy, or dd-MM";
-    public static final String MESSAGE_DATE_IN_PAST = "Assignment date must be in the future";
-    public static final String MESSAGE_INVALID_NAME = "Name should only contain alphanumeric"
-            + " characters and spaces, and it should not be blank";
+    public static final String MESSAGE_DATE_IN_PAST = "Assignment date must start from after today";
+    public static final String MESSAGE_INVALID_NAME = "Name should not be blank";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AssignmentCommand
@@ -46,8 +45,8 @@ public class AssignmentCommandParser implements Parser<AssignmentCommand> {
         String name = argMultimap.getValue(PREFIX_NAME).get();
         String dateStr = argMultimap.getValue(PREFIX_DATE).get();
 
-        // Validate name format
-        if (!name.matches("[\\p{Alnum}][\\p{Alnum} ]*")) {
+        // Validate name is not blank
+        if (name.trim().isEmpty()) {
             throw new ParseException(MESSAGE_INVALID_NAME);
         }
 

--- a/src/main/java/tassist/address/model/timedevents/TimedEvent.java
+++ b/src/main/java/tassist/address/model/timedevents/TimedEvent.java
@@ -14,8 +14,7 @@ import tassist.address.commons.util.ToStringBuilder;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public abstract class TimedEvent {
-    public static final String MESSAGE_NAME_CONSTRAINTS = "Name can only contain alphanumeric characters and spaces, "
-            + "and cannot start with a space";
+    public static final String MESSAGE_NAME_CONSTRAINTS = "Name should not be blank";
     public static final String MESSAGE_DESCRIPTION_CONSTRAINTS = "Description cannot be null";
 
     private final String name;
@@ -30,7 +29,7 @@ public abstract class TimedEvent {
         requireNonNull(description);
         requireNonNull(time);
 
-        if (!name.matches("[\\p{Alnum}][\\p{Alnum} ]*")) {
+        if (name.trim().isEmpty()) {
             throw new IllegalArgumentException(MESSAGE_NAME_CONSTRAINTS);
         }
 

--- a/src/test/java/tassist/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tassist/address/logic/commands/CommandTestUtil.java
@@ -79,7 +79,7 @@ public class CommandTestUtil {
     public static final String DATE_DESC_MID = " " + PREFIX_DATE + VALID_DATE_MID;
     public static final String DATE_DESC_SHORT = " " + PREFIX_DATE + VALID_DATE_SHORT;
     // Invalid assignment test strings
-    public static final String INVALID_ASSIGNMENT_NAME_SPECIAL = " " + PREFIX_NAME + "&" + DATE_DESC_LONG;
+    public static final String VALID_ASSIGNMENT_NAME_SPECIAL = " " + PREFIX_NAME + "&CS2103T Project";
     public static final String INVALID_ASSIGNMENT_NAME_EMPTY = " " + PREFIX_NAME + DATE_DESC_LONG;
     public static final String INVALID_ASSIGNMENT_NAME_SPACES = " " + PREFIX_NAME + "   " + DATE_DESC_LONG;
     public static final String INVALID_DATE_FORMAT = ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "2030-01-30";

--- a/src/test/java/tassist/address/logic/parser/AssignmentCommandParserTest.java
+++ b/src/test/java/tassist/address/logic/parser/AssignmentCommandParserTest.java
@@ -93,6 +93,20 @@ public class AssignmentCommandParserTest {
         // Today's date
         String today = LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"));
         assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + today, MESSAGE_DATE_IN_PAST);
+
+        // Invalid dates that should be caught
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "31-02-3926",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "29-02-3025",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "31-04-3026",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "31-06-3026",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "31-09-3026",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
+        assertParseFailure(parser, ASSIGNMENT_DESC_2103 + " " + PREFIX_DATE + "31-11-3026",
+                AssignmentCommandParser.MESSAGE_INVALID_DATE_VALUES);
     }
 
     @Test

--- a/src/test/java/tassist/address/logic/parser/AssignmentCommandParserTest.java
+++ b/src/test/java/tassist/address/logic/parser/AssignmentCommandParserTest.java
@@ -10,7 +10,6 @@ import static tassist.address.logic.commands.CommandTestUtil.EXTRA_ARGUMENTS;
 import static tassist.address.logic.commands.CommandTestUtil.EXTRA_PREFIX;
 import static tassist.address.logic.commands.CommandTestUtil.INVALID_ASSIGNMENT_NAME_EMPTY;
 import static tassist.address.logic.commands.CommandTestUtil.INVALID_ASSIGNMENT_NAME_SPACES;
-import static tassist.address.logic.commands.CommandTestUtil.INVALID_ASSIGNMENT_NAME_SPECIAL;
 import static tassist.address.logic.commands.CommandTestUtil.INVALID_DATE_FORMAT;
 import static tassist.address.logic.commands.CommandTestUtil.INVALID_DATE_PAST;
 import static tassist.address.logic.commands.CommandTestUtil.INVALID_DATE_VALUES;
@@ -18,6 +17,7 @@ import static tassist.address.logic.commands.CommandTestUtil.MULTIPLE_FIELDS_INP
 import static tassist.address.logic.commands.CommandTestUtil.MULTIPLE_INVALID_FIELDS_INPUT;
 import static tassist.address.logic.commands.CommandTestUtil.MULTIPLE_VALID_FIELDS_INPUT;
 import static tassist.address.logic.commands.CommandTestUtil.VALID_ASSIGNMENT_NAME;
+import static tassist.address.logic.commands.CommandTestUtil.VALID_ASSIGNMENT_NAME_SPECIAL;
 import static tassist.address.logic.commands.CommandTestUtil.VALID_DATE_SHORT;
 import static tassist.address.logic.parser.AssignmentCommandParser.MESSAGE_DATE_IN_PAST;
 import static tassist.address.logic.parser.AssignmentCommandParser.MESSAGE_INVALID_DATE;
@@ -98,14 +98,20 @@ public class AssignmentCommandParserTest {
     @Test
     public void parse_invalidName_failure() {
 
-        // Name starting with special character
-        assertParseFailure(parser, INVALID_ASSIGNMENT_NAME_SPECIAL, MESSAGE_INVALID_NAME);
-
         // Name with only spaces
         assertParseFailure(parser, INVALID_ASSIGNMENT_NAME_SPACES, MESSAGE_INVALID_NAME);
 
         // Empty name
         assertParseFailure(parser, INVALID_ASSIGNMENT_NAME_EMPTY, MESSAGE_INVALID_NAME);
+    }
+
+    @Test
+    public void parse_specialName_success() {
+        Assignment expectedAssignment = new Assignment("&CS2103T Project", "",
+                LocalDateTime.of(2025, 12, 20, 23, 59));
+        // Name starting with special character
+        assertParseSuccess(parser, VALID_ASSIGNMENT_NAME_SPECIAL + DATE_DESC_SHORT,
+                new AssignmentCommand(expectedAssignment));
     }
 
     @Test

--- a/src/test/java/tassist/address/storage/JsonAdaptedTimedEventTest.java
+++ b/src/test/java/tassist/address/storage/JsonAdaptedTimedEventTest.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.api.Test;
 import tassist.address.commons.exceptions.IllegalValueException;
 
 public class JsonAdaptedTimedEventTest {
-    private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_DESCRIPTION = " ";
+    private static final String INVALID_NAME = "";
     private static final String INVALID_TIME = "invalid-time";
     private static final String INVALID_TYPE = "InvalidType";
 


### PR DESCRIPTION
Add support for special characters in assignment name, closes #328 
Make sure invalid dates don't silently succeed, closes #320 
Modify UG and error messages to state that dates can only start from tomorrow, as well as state that assignments past deadline are kept for admin purpoess, and can be manually removed using `unassign`, closes #308 , closes #315 